### PR TITLE
Feature to use Environment Variables in toml configuration file

### DIFF
--- a/config.go
+++ b/config.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"fmt"
-	"github.com/BurntSushi/toml"
-	"github.com/pkg/errors"
 	"io/ioutil"
 	"net/url"
+	"os"
+
+	"github.com/BurntSushi/toml"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -194,12 +196,15 @@ func ReadConfig(tomlStr string) (*S3SFTPProxyConfig, error) {
 }
 
 func ReadConfigFromFile(tomlFile string) (*S3SFTPProxyConfig, error) {
-	tomlStr, err := ioutil.ReadFile(tomlFile)
+	tomlBytes, err := ioutil.ReadFile(tomlFile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to open %s", tomlFile)
 	}
 
-	cfg, err := ReadConfig(string(tomlStr))
+	tomlBytes := os.ExpandEnv(string(tomlBytes))
+
+	cfg, err := ReadConfig(string(tomlBytes))
+
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed to parse %s", tomlFile)
 	}


### PR DESCRIPTION
Hi,
i hope it is ok, that I contribute a small feature which was very easy to implement and go's a long way for me.

In container environments configs gets often passed don via ENV vars.

Especially one does not want to have aws keys in the config files (I know there are other options as well implemented) Nevertheless what I did was the following:

´´´ 
[buckets.test.credentials]
aws_access_key_id = "aaa"
aws_secret_access_key = "bbb" 
```
with this small change you could do something like this:

```
[buckets.test.credentials]
aws_access_key_id = "${ACCESS_KEY}"
aws_secret_access_key = "${SECRET_KEY}"
```
given `ACCESS_KEY' and 'SECRET_KEY' is defined as ENV vars it will expanded after loading the config file.

This does work with arbitrary ENV vars which are referenced in the config.

I hope you like the idea as well and like to merge this PR.

Best Regards

Felix