### PR TITLE
[server.go] Add formatting directive

### DIFF
--- a/server.go
+++ b/server.go
@@ -153,7 +153,7 @@ func (s *Server) HandleClient(ctx context.Context, conn *net.TCPConn) error {
 
 			sshCh, reqs, err := newSSHCh.Accept()
 			if err != nil {
-				F(s.Log.Error, "could not accept channel", err.Error())
+				F(s.Log.Error, "could not accept channel: %s", err.Error())
 				break
 			}
 


### PR DESCRIPTION
```
$ go test
# s3-sftp-proxy
./server.go:156:6: F call has arguments but no formatting directives
FAIL	s3-sftp-proxy [build failed]
```