### PR TITLE
Add audit logs

### DIFF
--- a/bucketio.go
+++ b/bucketio.go
@@ -438,7 +438,7 @@ type S3ObjectStat struct {
 }
 
 func (sos *S3ObjectStat) ListAt(result []os.FileInfo, o int64) (int, error) {
-	F(sos.Debug, "S3ObjectStat.: len(result)=%d offset=%d", len(result), o)
+	F(sos.Debug, "S3ObjectStat.ListAt: len(result)=%d offset=%d", len(result), o)
 	_o, err := castInt64ToInt(o)
 	if err != nil {
 		return 0, err
@@ -578,6 +578,7 @@ func (s3io *S3BucketIO) Fileread(req *sftp.Request) (io.ReaderAt, error) {
 
 	keyStr := key.String()
 	ctx := combineContext(s3io.Ctx, req.Context())
+	F(s3io.Log.Info, "Audit: User %s downloaded file \"%s\"", s3io.UserInfo.String(), keyStr)
 	F(s3io.Log.Debug, "GetObject(Bucket=%s, Key=%s)", s3io.Bucket.Bucket, keyStr)
 	sse := s3io.ServerSideEncryption
 	goo, err := s3.GetObjectWithContext(
@@ -620,7 +621,7 @@ func (s3io *S3BucketIO) Filewrite(req *sftp.Request) (io.WriterAt, error) {
 		Size:         0,
 		LastModified: s3io.Now(),
 	}
-	F(s3io.Log.Info, "Upload file %s by user %s", key, s3io.UserInfo.User)
+	F(s3io.Log.Info, "Audit: User %s uploaded file \"%s\"", s3io.UserInfo.String(), key)
 	F(s3io.Log.Debug, "S3PutObjectWriter.New(key=%s)", key)
 	oow := &S3PutObjectWriter{
 		Ctx:                  combineContext(s3io.Ctx, req.Context()),
@@ -658,6 +659,7 @@ func (s3io *S3BucketIO) Filecmd(req *sftp.Request) error {
 		destStr := dest.String()
 		copySource := s3io.Bucket.Bucket + "/" + srcStr
 		sse := s3io.ServerSideEncryption
+		F(s3io.Log.Info, "Audit: User %s renamed \"%s\" to \"%s\"", s3io.UserInfo.String(), srcStr, destStr)
 		F(s3io.Log.Debug, "CopyObject(Bucket=%s, Key=%s, CopySource=%s, Sse=%v)", s3io.Bucket.Bucket, destStr, copySource, sse.Type)
 		_, err = s3io.Bucket.S3(sess).CopyObjectWithContext(
 			combineContext(s3io.Ctx, req.Context()),
@@ -702,6 +704,7 @@ func (s3io *S3BucketIO) Filecmd(req *sftp.Request) error {
 			return err
 		}
 		keyStr := key.String()
+		F(s3io.Log.Info, "Audit: User %s deleted file \"%s\"", s3io.UserInfo.String(), key)
 		F(s3io.Log.Debug, "DeleteObject(Bucket=%s, Key=%s)", s3io.Bucket.Bucket, key)
 		_, err = s3io.Bucket.S3(sess).DeleteObjectWithContext(
 			combineContext(s3io.Ctx, req.Context()),
@@ -728,6 +731,7 @@ func (s3io *S3BucketIO) Filelist(req *sftp.Request) (sftp.ListerAt, error) {
 		if !s3io.Perms.Readable && !s3io.Perms.Listable {
 			return nil, fmt.Errorf("stat operation not allowed as per configuration")
 		}
+		F(s3io.Log.Info, "Audit: User %s read path stats \"%s\"", s3io.UserInfo.String(), req.Filepath)
 		key := buildKey(s3io.Bucket, req.Filepath)
 		return &S3ObjectStat{
 			DebugLogger:      s3io.Log,
@@ -742,6 +746,7 @@ func (s3io *S3BucketIO) Filelist(req *sftp.Request) (sftp.ListerAt, error) {
 		if !s3io.Perms.Listable {
 			return nil, fmt.Errorf("listing operation not allowed as per configuration")
 		}
+		F(s3io.Log.Info, "Audit: User %s listed path \"%s\"", s3io.UserInfo.String(), req.Filepath)
 		return &S3ObjectLister{
 			DebugLogger:      s3io.Log,
 			Ctx:              combineContext(s3io.Ctx, req.Context()),

--- a/bucketio.go
+++ b/bucketio.go
@@ -160,6 +160,7 @@ type S3PutObjectWriter struct {
 	ServerSideEncryption *ServerSideEncryptionConfig
 	Log                  interface {
 		DebugLogger
+		InfoLogger
 		ErrorLogger
 	}
 	MaxObjectSize    int64
@@ -437,7 +438,7 @@ type S3ObjectStat struct {
 }
 
 func (sos *S3ObjectStat) ListAt(result []os.FileInfo, o int64) (int, error) {
-	F(sos.Debug, "S3ObjectStat.ListAt: len(result)=%d offset=%d", len(result), o)
+	F(sos.Debug, "S3ObjectStat.: len(result)=%d offset=%d", len(result), o)
 	_o, err := castInt64ToInt(o)
 	if err != nil {
 		return 0, err
@@ -541,8 +542,10 @@ type S3BucketIO struct {
 	Now                      func() time.Time
 	Log                      interface {
 		ErrorLogger
+		InfoLogger
 		DebugLogger
 	}
+	UserInfo *UserInfo
 }
 
 func buildKey(s3b *S3Bucket, path string) Path {
@@ -617,6 +620,7 @@ func (s3io *S3BucketIO) Filewrite(req *sftp.Request) (io.WriterAt, error) {
 		Size:         0,
 		LastModified: s3io.Now(),
 	}
+	F(s3io.Log.Info, "Upload file %s by user %s", key, s3io.UserInfo.User)
 	F(s3io.Log.Debug, "S3PutObjectWriter.New(key=%s)", key)
 	oow := &S3PutObjectWriter{
 		Ctx:                  combineContext(s3io.Ctx, req.Context()),

--- a/bucketio.go
+++ b/bucketio.go
@@ -160,7 +160,6 @@ type S3PutObjectWriter struct {
 	ServerSideEncryption *ServerSideEncryptionConfig
 	Log                  interface {
 		DebugLogger
-		InfoLogger
 		ErrorLogger
 	}
 	MaxObjectSize    int64
@@ -542,7 +541,7 @@ type S3BucketIO struct {
 	Now                      func() time.Time
 	Log                      interface {
 		ErrorLogger
-		InfoLogger
+		WarnLogger
 		DebugLogger
 	}
 	UserInfo *UserInfo
@@ -578,7 +577,7 @@ func (s3io *S3BucketIO) Fileread(req *sftp.Request) (io.ReaderAt, error) {
 
 	keyStr := key.String()
 	ctx := combineContext(s3io.Ctx, req.Context())
-	F(s3io.Log.Info, "Audit: User %s downloaded file \"%s\"", s3io.UserInfo.String(), keyStr)
+	F(s3io.Log.Warn, "Audit: User %s downloaded file \"%s\"", s3io.UserInfo.String(), keyStr)
 	F(s3io.Log.Debug, "GetObject(Bucket=%s, Key=%s)", s3io.Bucket.Bucket, keyStr)
 	sse := s3io.ServerSideEncryption
 	goo, err := s3.GetObjectWithContext(
@@ -621,7 +620,7 @@ func (s3io *S3BucketIO) Filewrite(req *sftp.Request) (io.WriterAt, error) {
 		Size:         0,
 		LastModified: s3io.Now(),
 	}
-	F(s3io.Log.Info, "Audit: User %s uploaded file \"%s\"", s3io.UserInfo.String(), key)
+	F(s3io.Log.Warn, "Audit: User %s uploaded file \"%s\"", s3io.UserInfo.String(), key)
 	F(s3io.Log.Debug, "S3PutObjectWriter.New(key=%s)", key)
 	oow := &S3PutObjectWriter{
 		Ctx:                  combineContext(s3io.Ctx, req.Context()),
@@ -659,7 +658,7 @@ func (s3io *S3BucketIO) Filecmd(req *sftp.Request) error {
 		destStr := dest.String()
 		copySource := s3io.Bucket.Bucket + "/" + srcStr
 		sse := s3io.ServerSideEncryption
-		F(s3io.Log.Info, "Audit: User %s renamed \"%s\" to \"%s\"", s3io.UserInfo.String(), srcStr, destStr)
+		F(s3io.Log.Warn, "Audit: User %s renamed \"%s\" to \"%s\"", s3io.UserInfo.String(), srcStr, destStr)
 		F(s3io.Log.Debug, "CopyObject(Bucket=%s, Key=%s, CopySource=%s, Sse=%v)", s3io.Bucket.Bucket, destStr, copySource, sse.Type)
 		_, err = s3io.Bucket.S3(sess).CopyObjectWithContext(
 			combineContext(s3io.Ctx, req.Context()),
@@ -704,7 +703,7 @@ func (s3io *S3BucketIO) Filecmd(req *sftp.Request) error {
 			return err
 		}
 		keyStr := key.String()
-		F(s3io.Log.Info, "Audit: User %s deleted file \"%s\"", s3io.UserInfo.String(), key)
+		F(s3io.Log.Warn, "Audit: User %s deleted file \"%s\"", s3io.UserInfo.String(), key)
 		F(s3io.Log.Debug, "DeleteObject(Bucket=%s, Key=%s)", s3io.Bucket.Bucket, key)
 		_, err = s3io.Bucket.S3(sess).DeleteObjectWithContext(
 			combineContext(s3io.Ctx, req.Context()),
@@ -731,7 +730,7 @@ func (s3io *S3BucketIO) Filelist(req *sftp.Request) (sftp.ListerAt, error) {
 		if !s3io.Perms.Readable && !s3io.Perms.Listable {
 			return nil, fmt.Errorf("stat operation not allowed as per configuration")
 		}
-		F(s3io.Log.Info, "Audit: User %s read path stats \"%s\"", s3io.UserInfo.String(), req.Filepath)
+		F(s3io.Log.Warn, "Audit: User %s read path stats \"%s\"", s3io.UserInfo.String(), req.Filepath)
 		key := buildKey(s3io.Bucket, req.Filepath)
 		return &S3ObjectStat{
 			DebugLogger:      s3io.Log,
@@ -746,7 +745,7 @@ func (s3io *S3BucketIO) Filelist(req *sftp.Request) (sftp.ListerAt, error) {
 		if !s3io.Perms.Listable {
 			return nil, fmt.Errorf("listing operation not allowed as per configuration")
 		}
-		F(s3io.Log.Info, "Audit: User %s listed path \"%s\"", s3io.UserInfo.String(), req.Filepath)
+		F(s3io.Log.Warn, "Audit: User %s listed path \"%s\"", s3io.UserInfo.String(), req.Filepath)
 		return &S3ObjectLister{
 			DebugLogger:      s3io.Log,
 			Ctx:              combineContext(s3io.Ctx, req.Context()),

--- a/logging.go
+++ b/logging.go
@@ -8,6 +8,10 @@ type InfoLogger interface {
 	Info(args ...interface{})
 }
 
+type WarnLogger interface {
+	Warn(args ...interface{})
+}
+
 type ErrorLogger interface {
 	Error(args ...interface{})
 }

--- a/server.go
+++ b/server.go
@@ -36,7 +36,7 @@ func asHandlers(handlers interface {
 	return sftp.Handlers{handlers, handlers, handlers, handlers}
 }
 
-func (s *Server) HandleChannel(ctx context.Context, bucket *S3Bucket, sshCh ssh.Channel, reqs <-chan *ssh.Request) {
+func (s *Server) HandleChannel(ctx context.Context, bucket *S3Bucket, sshCh ssh.Channel, reqs <-chan *ssh.Request, userInfo *UserInfo) {
 	defer s.Log.Debug("HandleChannel ended")
 	server := sftp.NewRequestServer(
 		sshCh,
@@ -52,6 +52,7 @@ func (s *Server) HandleChannel(ctx context.Context, bucket *S3Bucket, sshCh ssh.
 				Perms:                    bucket.Perms,
 				ServerSideEncryption:     &bucket.ServerSideEncryption,
 				Now:                      s.Now,
+				UserInfo:                 userInfo,
 			},
 		),
 	)
@@ -106,6 +107,10 @@ func (s *Server) HandleClient(ctx context.Context, conn *net.TCPConn) error {
 		F(s.Log.Info, "connection from client %s closed", conn.RemoteAddr().String())
 		conn.Close()
 	}()
+
+	var userInfo *UserInfo = new(UserInfo)
+	userInfo.Addr = conn.RemoteAddr()
+
 	F(s.Log.Info, "connected from client %s", conn.RemoteAddr().String())
 
 	innerCtx, cancel := context.WithCancel(ctx)
@@ -122,6 +127,7 @@ func (s *Server) HandleClient(ctx context.Context, conn *net.TCPConn) error {
 		return err
 	}
 
+	userInfo.User = sconn.User()
 	F(s.Log.Info, "user %s logged in", sconn.User())
 	bucket, ok := s.UserToBucketMap[sconn.User()]
 	if !ok {
@@ -160,7 +166,7 @@ func (s *Server) HandleClient(ctx context.Context, conn *net.TCPConn) error {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				s.HandleChannel(innerCtx, bucket, sshCh, reqs)
+				s.HandleChannel(innerCtx, bucket, sshCh, reqs, userInfo)
 			}()
 		}
 	}(chans)

--- a/server.go
+++ b/server.go
@@ -22,6 +22,7 @@ type Server struct {
 	Log                      interface {
 		DebugLogger
 		InfoLogger
+		WarnLogger
 		ErrorLogger
 	}
 	Now func() time.Time

--- a/user_info.go
+++ b/user_info.go
@@ -1,8 +1,15 @@
 package main
 
-import "net"
+import (
+	"fmt"
+	"net"
+)
 
 type UserInfo struct {
-	Addr  net.Addr
+	Addr net.Addr
 	User string
+}
+
+func (uInfo UserInfo) String() string {
+	return fmt.Sprintf("%s from %s", uInfo.User, uInfo.Addr.String())
 }

--- a/user_info.go
+++ b/user_info.go
@@ -1,0 +1,8 @@
+package main
+
+import "net"
+
+type UserInfo struct {
+	Addr  net.Addr
+	User string
+}


### PR DESCRIPTION
I'm using this tool on one of the projects in production.

For security reasons it's very useful to see who has done which actions.
Suddenly current logs doesn't expose this information (in single message), so I have added separate Audit log messages.